### PR TITLE
Fix misreported sensor status

### DIFF
--- a/Packs/Carbon_Black_Enterprise_Response/Integrations/CarbonBlackResponseV2/CarbonBlackResponseV2.py
+++ b/Packs/Carbon_Black_Enterprise_Response/Integrations/CarbonBlackResponseV2/CarbonBlackResponseV2.py
@@ -725,7 +725,7 @@ def endpoint_command(client: Client, id: str = None, ip: str = None, hostname: s
                 mac_address=_parse_field(sensor.get('network_adapters', ''), index_after_split=1, chars_to_remove='|'),
                 os_version=sensor.get('os_environment_display_string'),
                 memory=sensor.get('physical_memory_size'),
-                status='Online' if sensor.get('status') else 'Offline',
+                status='Online' if sensor.get('status') == 'Online' else 'Offline',
                 is_isolated=is_isolated,
                 vendor='Carbon Black Response')
             endpoints.append(endpoint)


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Sensor status can be misreported as `Online` due to a values that were not originally anticipated.

The logic that assigns the `Online` tag simply checks to see if the `status` field exists. However, there are cases where the field can exist but not be the value `Online`. I have identified an edge case where the status can be `Uninstall Pending`.

To fix this issue, I have added an additional check to ensure that the status exists and is `Online`.

## Screenshots
I have provided 3 screenshots:
- The first is the raw-response of the command `endpoint` which shows a status of `Uninstall Pending`.
- The second is a screenshot of the output of `endpoint` without raw-response, which shows that the status is listed as online.
- The third is a screenshot showing the results of the `endpoint` command with this patch applied, showing that a proper status of `Offline` is shown.

![2023-01-04_9-50-18](https://user-images.githubusercontent.com/6716948/210589466-c323e7a0-de89-496f-9a8c-7522b50a6b28.jpg)

![2023-01-04_9-49-40](https://user-images.githubusercontent.com/6716948/210589583-d4052fe7-3d59-42a5-8bb4-c546ff57511a.jpg)

![Capture](https://user-images.githubusercontent.com/6716948/210590315-c0424a65-e717-4eba-a577-ccf558a9dfe8.PNG)


## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [ x ] No

## Must have
- [x] Tests
- [x] Documentation 
